### PR TITLE
Add action_types fixture instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ image was last built, you’ll need to rebuild the image:
 
 2. Ensure you have a `MAPIT_API_KEY` in your `.env` file.
 
-3. Run `./manage.py add_random_cases --uprns UPRN_FILE --number 100 --commit`
+3. Run `./manage.py loaddata action_types`
+
+4. Run `./manage.py add_random_cases --uprns UPRN_FILE --number 100 --commit`
+
+If you are running inside Docker you will want to enter a shell in the `web` container first:
+`docker-compose exec web bash`
 
 ### Tests
 


### PR DESCRIPTION
Setting up the project today, I noticed we didn't have any instructions about loading action_types. So I added it on the README file
