### PR TITLE
Add recurrence form

### DIFF
--- a/cases/forms/__init__.py
+++ b/cases/forms/__init__.py
@@ -1,3 +1,4 @@
 from .case import *
 from .filter import *
 from .person import *
+from .recurrence import *

--- a/cases/forms/person.py
+++ b/cases/forms/person.py
@@ -7,8 +7,7 @@ from noiseworks.forms import GDSForm
 
 
 class PersonPickForm(GDSForm, forms.Form):
-    submit_text = "Add"
-    log_note = "Added perpetrator"
+    submit_text = "Submit"
 
     search = forms.CharField(widget=forms.HiddenInput)
     user = forms.ChoiceField(widget=forms.RadioSelect)
@@ -21,15 +20,18 @@ class PersonPickForm(GDSForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         search = self.data.get("search") or self.initial.get("search")
-        search = search.lower()
-        choices = User.objects.filter(
-            Q(first_name__icontains=search)
-            | Q(last_name__icontains=search)
-            | Q(address__icontains=search)
-            | Q(email__icontains=search)
-            | Q(phone__icontains=search)
-        )
-        choices = list(map(lambda x: (x.id, str(x)), choices))
+        if search:
+            search = search.lower()
+            choices = User.objects.filter(
+                Q(first_name__icontains=search)
+                | Q(last_name__icontains=search)
+                | Q(address__icontains=search)
+                | Q(email__icontains=search)
+                | Q(phone__icontains=search)
+            )
+            choices = list(map(lambda x: (x.id, str(x)), choices))
+        else:
+            choices = []
         choices.append((0, "None, details below"))
         self.fields["user"].choices = choices
 
@@ -38,10 +40,14 @@ class PersonPickForm(GDSForm, forms.Form):
             if (
                 not self.cleaned_data["first_name"]
                 or not self.cleaned_data["last_name"]
-                or not (self.cleaned_data["email"] or self.cleaned_data["phone"])
+                or not (
+                    self.cleaned_data.get("email")
+                    or self.cleaned_data.get("phone")
+                    or self.cleaned_data["address"]
+                )
             ):
                 raise forms.ValidationError(
-                    "Please specify a name and at least one of email/phone"
+                    "Please specify a name and at least one of email/phone/address"
                 )
 
     def clean_user(self):
@@ -49,22 +55,36 @@ class PersonPickForm(GDSForm, forms.Form):
         if user == "0":
             return None
         user = User.objects.get(id=user)
-        return user
+        return user.id
 
-    def save(self, case):
+    def save(self):
         user = self.cleaned_data.pop("user")
         search = self.cleaned_data.pop("search")
         if not user:
             user = User.objects.create_user(**self.cleaned_data)
-        case.perpetrators.add(user)
-        case.save()
-        typ, _ = ActionType.objects.get_or_create(
-            name="Edit case", defaults={"visibility": "internal"}
-        )
-        Action.objects.create(case=case, type=typ, notes=self.log_note)
+            return user.id
+        return user
 
 
 class PersonSearchForm(GDSForm, forms.Form):
     submit_text = "Search"
 
-    search = forms.CharField()
+    search = forms.CharField(label="Search for person")
+
+
+class RecurrencePersonSearchForm(PersonSearchForm):
+    title = "Reporting user"
+
+
+class PerpetratorPickForm(PersonPickForm):
+    submit_text = "Add"
+    log_note = "Added perpetrator"
+
+    def save(self, case):
+        user_id = super().save()
+        case.perpetrators.add(user_id)
+        case.save()
+        typ, _ = ActionType.objects.get_or_create(
+            name="Edit case", defaults={"visibility": "internal"}
+        )
+        Action.objects.create(case=case, type=typ, notes=self.log_note)

--- a/cases/forms/recurrence.py
+++ b/cases/forms/recurrence.py
@@ -1,0 +1,89 @@
+import datetime
+from django import forms
+
+# from django.core.exceptions import ValidationError
+from crispy_forms_gds.fields import DateInputField
+from noiseworks.forms import GDSForm
+
+
+class StepForm(GDSForm, forms.Form):
+    submit_text = "Next"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.form_tag = False
+
+
+class TimeWidget(forms.TextInput):
+    pass
+
+
+def coerce_to_date(d):
+    if d == "today":
+        return datetime.date.today()
+    else:  # "yesterday"
+        return datetime.date.today() - datetime.timedelta(days=1)
+
+
+class IsItHappeningNowForm(StepForm):
+    happening_now = forms.TypedChoiceField(
+        choices=((1, "Yes"), (0, "No")),
+        widget=forms.RadioSelect,
+        coerce=int,
+        label="Is the noise happening right now?",
+    )
+
+
+class HappeningNowForm(StepForm):
+    start_date = forms.TypedChoiceField(
+        choices=(("today", "Today"), ("yesterday", "Yesterday")),
+        widget=forms.RadioSelect,
+        label="When did today’s noise start?",
+        coerce=coerce_to_date,
+    )
+    start_time = forms.TimeField(
+        help_text="For example, 9pm or 2:30am – enter 12am for midnight",
+        widget=TimeWidget,
+    )
+
+
+class NotHappeningNowForm(StepForm):
+    start_date = DateInputField(require_all_fields=False)
+    start_time = forms.TimeField(
+        help_text="For example, 9pm or 2:30am – enter 12am for midnight",
+        widget=TimeWidget,
+    )
+    end_time = forms.TimeField(
+        help_text="For example, 10pm or 3:30am – enter 12pm for midday",
+        widget=TimeWidget,
+    )
+
+
+class RoomsAffectedForm(StepForm):
+    title = "Details of the noise"
+    rooms = forms.CharField(
+        widget=forms.Textarea, label="Which rooms in your property are affected?"
+    )
+
+
+class DescribeNoiseForm(StepForm):
+    title = "Details of the noise"
+    description = forms.CharField(
+        widget=forms.Textarea, label="Can you describe the noise?"
+    )
+
+
+class EffectForm(StepForm):
+    title = "Details of the noise"
+    effect = forms.CharField(
+        widget=forms.Textarea, label="What effect has the noise had on you?"
+    )
+
+
+class SummaryForm(StepForm):
+    submit_text = "Submit"
+    title = "Check your answers"
+
+    true_statement = forms.BooleanField(
+        label="This statement is true to the best of my knowledge and belief and I make it knowing that, if it is tendered in evidence, I shall be liable to prosecution if I have wilfully stated in it anything which I know to be false or do not believe to be true."
+    )

--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -78,11 +78,13 @@
 </dl>
 
 {% if not case.merged_into %}
-
+<div class="nw-button-bar">
     <a href="{% url "case-log-action" case.id %}" class="nw-button">Log an action</a>
-    {% if not duplicate and not case.merged_into %}
-        <a href="{% url "case-merge" case.id %}" class="nw-button nw-button--secondary">Merge into another case</a>
-    {% endif %}
+    <a href="{% url "complaint-add" case.id %}" class="nw-button nw-button--secondary">Report a reoccurrence</a>
+  {% if not duplicate %}
+    <a href="{% url "case-merge" case.id %}" class="nw-button nw-button--secondary">Merge into another case</a>
+  {% endif %}
+</div>
 {% endif %}
 
 <h2 class="lbh-heading-h2 section-heading">Noise Source</h2>

--- a/cases/templates/cases/complaint_add.html
+++ b/cases/templates/cases/complaint_add.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags crispy_forms_gds %}
+
+{% block content %}
+
+<div>
+    <a href="{% url "case-view" case.id %}" class="nw-back-link">Back to case #{{ case.id }}</a>
+</div>
+
+<div class="nw-merge-source">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body">
+            <strong>{{ case.kind_display }} at {{ case.location_display }}</strong>
+            </p>
+            <p class="govuk-body" style="margin-bottom:0">
+            Case reference <strong>{{ case.id }}</strong>
+            </p>
+        </div>
+    </div>
+</div>
+
+{% error_summary wizard.form %}
+
+{% if wizard.form.title %}
+<h1 class="govuk-heading-l govuk-!-margin-top-7">{{ wizard.form.title }}</h1>
+{% endif %}
+
+{% if wizard.steps.current == "summary" %}
+
+<dl class="nw-summary-list govuk-!-margin-bottom-8">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Noise started again</dt>
+    <dd class="govuk-summary-list__value">{{ data.start_date }}, {{ data.start_time }}</dd>
+    <dd class="govuk-summary-list__actions">
+    <a class="nw-link--no-visited-state" href="isitnow">
+        Change<span class="govuk-visually-hidden"> start time</span>
+      </a>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Noise ended</dt>
+    <dd class="govuk-summary-list__value">
+     {% if data.happening_now %}
+     Still ongoing at {% now "P, D j M Y" %}
+     {% else %}
+      {{ data.start_date }}, {{ data.end_time }}
+     {% endif %}
+    </dd>
+    <dd class="govuk-summary-list__actions">
+      <a class="nw-link--no-visited-state" href="{% if data.happening_now %}isnow{% else %}notnow{% endif %}">
+        Change<span class="govuk-visually-hidden"> end time</span>
+      </a>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Rooms affected</dt>
+    <dd class="govuk-summary-list__value">{{ data.rooms }}</dd>
+    <dd class="govuk-summary-list__actions">
+      <a class="nw-link--no-visited-state" href="rooms">
+        Change<span class="govuk-visually-hidden"> rooms</span>
+      </a>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Noise description</dt>
+    <dd class="govuk-summary-list__value">{{ data.description }}</dd>
+    <dd class="govuk-summary-list__actions">
+      <a class="nw-link--no-visited-state" href="describe">
+        Change<span class="govuk-visually-hidden"> description</span>
+      </a>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Effect on you</dt>
+    <dd class="govuk-summary-list__value">{{ data.effect }}</dd>
+    <dd class="govuk-summary-list__actions">
+      <a class="nw-link--no-visited-state" href="effect">
+        Change<span class="govuk-visually-hidden"> effect</span>
+      </a>
+    </dd>
+  </div>
+{% if reporting_user %}
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Reporting user</dt>
+    <dd class="govuk-summary-list__value">{{ reporting_user }}</dd>
+    <dd class="govuk-summary-list__actions">
+      <a class="nw-link--no-visited-state" href="user_search">
+        Change<span class="govuk-visually-hidden"> user</span>
+      </a>
+    </dd>
+  </div>
+{% endif %}
+</dl>
+
+{% endif %}
+
+<form action="" method="post">
+{{ wizard.management_form }}
+{% crispy wizard.form %}
+
+<p><a href="{% url "complaint-add" case.id %}">Cancel</a></p>
+
+</form>
+
+{% endblock %}

--- a/cases/templates/cases/complaint_add_done.html
+++ b/cases/templates/cases/complaint_add_done.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags crispy_forms_gds %}
+
+{% block content %}
+
+<div class="nw-panel">
+    <h1 class="govuk-panel__title">Reoccurrence logged</h1>
+    <div class="govuk-panel__body">
+        Case reference {{ case.id }}
+    </div>
+</div>
+
+<h2>What happens next?</h2>
+
+<p>...</p>
+
+<p>
+    <a href="{% url "case-view" case.id %}">Show the updated case log for this complaint</a>
+</p>
+
+{% endblock %}

--- a/cases/templates/cases/edit-kind.html
+++ b/cases/templates/cases/edit-kind.html
@@ -18,19 +18,5 @@
     {% crispy form %}
 </fieldset>
 
-<script>
-    document.querySelectorAll('input[name="kind"]').forEach(function(i) {
-        i.addEventListener('change', function(e) {
-            if (e.currentTarget.value == "other") {
-                document.getElementById('div_id_kind_other').style.display = 'block';
-            } else {
-                document.getElementById('div_id_kind_other').style.display = 'none';
-            }
-        });
-    });
-    var el = document.querySelector('input[name="kind"]:checked');
-    el.dispatchEvent(new Event('change'));
-</script>
-
 {% endblock %}
 

--- a/cases/tests/test_recurrence.py
+++ b/cases/tests/test_recurrence.py
@@ -1,0 +1,148 @@
+import datetime
+from functools import partial
+import pytest
+from pytest_django.asserts import assertContains
+from accounts.models import User
+from ..models import Case, Complaint
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def normal_user(db):
+    return User.objects.create(
+        username="normal@example.org",
+        email="normal@example.org",
+        email_verified=True,
+        phone="+447700900123",
+        address="1 High Street",
+        first_name="Normal",
+        last_name="User",
+        best_time=["weekends"],
+        best_method="phone",
+    )
+
+
+@pytest.fixture
+def case_1(db, normal_user):
+    return Case.objects.create(kind="diy", created_by=normal_user, ward="E05009373")
+
+
+@pytest.fixture
+def complaint(db, case_1, normal_user):
+    return Complaint.objects.create(
+        case=case_1,
+        complainant=normal_user,
+        happening_now=True,
+    )
+
+
+def _post_step(admin_client, case_1, step, data, **kwargs):
+    return admin_client.post(
+        f"/cases/{case_1.id}/complaint/add/{step}",
+        {f"recurrence_wizard_{case_1.id}-current_step": step, **data},
+        **kwargs,
+    )
+
+
+def test_normal_user_permission(client, normal_user, case_1, complaint):
+    client.force_login(normal_user)
+    resp = client.get(f"/cases/{case_1.id}/complaint/add")
+    assert resp.status_code == 302
+    complaint.delete()
+    resp = client.get(f"/cases/{case_1.id}/complaint/add")
+    assert resp.status_code == 404
+
+
+def test_add_complaint_now_existing_user(admin_client, case_1, normal_user):
+    post_step = partial(_post_step, admin_client, case_1)
+
+    admin_client.get(f"/cases/{case_1.id}/complaint/add", follow=True)
+
+    post_step("isitnow", {"isitnow-happening_now": "1"})
+    post_step("isnow", {"isnow-start_date": "today", "isnow-start_time": "9pm"})
+    post_step("isnow", {"isnow-start_date": "yesterday", "isnow-start_time": "9pm"})
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+
+    post_step("rooms", {"rooms-rooms": "Room"})
+    post_step("describe", {"describe-description": "Desc"})
+    post_step("effect", {"effect-effect": "Effect"})
+
+    post_step("user_search", {"user_search-search": "Normal"})
+    resp = post_step(
+        "user_pick",
+        {"user_pick-search": "Normal", "user_pick-user": normal_user.id},
+        follow=True,
+    )
+    assertContains(resp, f"{yesterday.strftime('%a, %d %b %Y')}, 9 p.m.")
+    assertContains(resp, "Still ongoing")
+    assertContains(resp, "Normal User, 1 High Street")
+
+    post_step("summary", {"summary-true_statement": 1})
+
+    admin_client.get(f"/cases/{case_1.id}/complaint/add/done")
+
+
+def _test_add_complaint_not_now_new_user(admin_client, case_1, normal_user, user_data):
+    post_step = partial(_post_step, admin_client, case_1)
+
+    admin_client.get(f"/cases/{case_1.id}/complaint/add")
+
+    post_step("isitnow", {"isitnow-happening_now": "0"})
+    post_step("notnow", {})  # Test blank date submission
+    post_step(
+        "notnow",
+        {
+            "notnow-start_date_0": "100",
+            "notnow-start_date_1": "12",
+            "notnow-start_date_2": "2021",
+        },
+    )  # Test bad date submission
+    post_step(
+        "notnow",
+        {
+            "notnow-start_date_0": "12",
+            "notnow-start_date_1": "11",
+            "notnow-start_date_2": "2021",
+            "notnow-start_time": "9pm",
+            "notnow-end_time": "10pm",
+        },
+    )
+
+    post_step("rooms", {"rooms-rooms": "Room"})
+    post_step("describe", {"describe-description": "Desc"})
+    post_step("effect", {"effect-effect": "Effect"})
+
+    post_step("user_search", {"user_search-search": "Normal"})
+
+    resp = post_step("user_pick", {"user_pick-search": "Normal", "user_pick-user": 0})
+    assertContains(resp, "Please specify a name")
+    resp = post_step(
+        "user_pick",
+        {
+            "user_pick-search": "Normal",
+            "user_pick-user": 0,
+            "user_pick-first_name": "Norman",
+            "user_pick-last_name": "Normal",
+            **user_data,
+        },
+        follow=True,
+    )
+    assertContains(resp, "Fri, 12 Nov 2021, 9 p.m.")
+    assertContains(resp, "Fri, 12 Nov 2021, 10 p.m.")
+    assertContains(resp, "Norman Normal")
+
+    post_step("summary", {"summary-true_statement": 1})
+    admin_client.get(f"/cases/{case_1.id}/complaint/add/done")
+
+
+def test_add_complaint_not_now_new_user_email(admin_client, case_1, normal_user):
+    _test_add_complaint_not_now_new_user(
+        admin_client, case_1, normal_user, {"user_pick-email": "norman@example.org"}
+    )
+
+
+def test_add_complaint_not_now_new_user_phone(admin_client, case_1, normal_user):
+    _test_add_complaint_not_now_new_user(
+        admin_client, case_1, normal_user, {"user_pick-phone": "07900000000"}
+    )

--- a/cases/urls.py
+++ b/cases/urls.py
@@ -1,9 +1,16 @@
 from django.urls import path
 from . import views
 
+recurrence_wizard = views.RecurrenceWizard.as_view(url_name="complaint-add-step")
+
+
 urlpatterns = [
     path("", views.case_list, name="cases"),
     path("/<int:pk>", views.case, name="case-view"),
+    path("/<int:pk>/complaint/add", recurrence_wizard, name="complaint-add"),
+    path(
+        "/<int:pk>/complaint/add/<step>", recurrence_wizard, name="complaint-add-step"
+    ),
     path("/<int:pk>/complaint/<int:complaint>", views.complaint, name="complaint"),
     path("/<int:pk>/edit-kind", views.edit_kind, name="case-edit-kind"),
     path("/<int:pk>/edit-location", views.edit_location, name="case-edit-location"),

--- a/cobrand_hackney/static/_buttons.scss
+++ b/cobrand_hackney/static/_buttons.scss
@@ -1,0 +1,11 @@
+.nw-button-bar {
+    @include govuk-media-query($from: tablet) {
+        display: flex;
+        flex-wrap: wrap;
+        margin: 2rem -0.5rem -0.5rem -0.5rem;
+
+        & > * {
+            margin: 0.5rem;
+        }
+    }
+}

--- a/cobrand_hackney/static/_forms.scss
+++ b/cobrand_hackney/static/_forms.scss
@@ -1,0 +1,18 @@
+.govuk-checkboxes--small {
+    .govuk-checkboxes__item {
+        margin-bottom: 0.5rem;
+    }
+
+    .govuk-label {
+        margin-bottom: 0;
+        padding-top: 0.3rem;
+        padding-bottom: 0.3rem;
+    }
+}
+
+// Line up the top of very long label with
+// the top of the checkbox next to it.
+#div_id_summary-true_statement label {
+    margin-top: -0.3em; // compensate for line-height
+    padding-top: 0;
+}

--- a/cobrand_hackney/static/app.scss
+++ b/cobrand_hackney/static/app.scss
@@ -4,6 +4,11 @@ $lbh-asset-path: "/static/hackney";
 
 @import "node_modules/lbh-frontend/lbh/all";
 
+.nw-panel {
+    @extend .govuk-panel;
+    @extend .govuk-panel--confirmation;
+    @extend .lbh-panel;
+}
 .nw-list {
     @extend .govuk-list;
     @extend .lbh-list;
@@ -65,6 +70,8 @@ $lbh-asset-path: "/static/hackney";
 @import "variables";
 @import "colours";
 @import "typography";
+@import "forms";
+@import "buttons";
 
 @import "timeline";
 @import "sections";
@@ -238,18 +245,6 @@ ul.case-list-user li {
 
     .lbh-select {
         width: 100%;
-    }
-}
-
-.govuk-checkboxes--small {
-    .govuk-checkboxes__item {
-        margin-bottom: 0.5rem;
-    }
-
-    .govuk-label {
-        margin-bottom: 0;
-        padding-top: 0.3rem;
-        padding-bottom: 0.3rem;
     }
 }
 

--- a/cobrand_hackney/static/js.js
+++ b/cobrand_hackney/static/js.js
@@ -36,4 +36,36 @@ document.querySelectorAll('.case-detail__map__overlay').forEach(function(b) {
     });
 });
 
+/* Generic script for handling show-this-or-not-if-this-selected */
+
+function show_hide_toggle(b, ids) {
+    b = b ? 'block' : 'none';
+    ids.forEach(function(el) {
+        document.getElementById(el).style.display = b;
+    });
+}
+function show_hide(input, value, ids) {
+    var inputs = document.querySelectorAll('input[name="' + input + '"]');
+    inputs.forEach(function(i) {
+        i.addEventListener('change', function(e) {
+            if (e.currentTarget.value == value) {
+                show_hide_toggle(true, ids);
+            } else {
+                show_hide_toggle(false, ids);
+            }
+        });
+    });
+    if (inputs.length) {
+        var el = document.querySelector('input[name="' + input + '"]:checked');
+        if (el) {
+            el.dispatchEvent(new Event('change'));
+        } else {
+            show_hide_toggle(false, ids);
+        }
+    }
+}
+
+show_hide("kind", "other", ["div_id_kind_other"]);
+show_hide("user_pick-user", "0", ['div_id_user_pick-first_name', 'div_id_user_pick-last_name', 'div_id_user_pick-email', 'div_id_user_pick-phone', 'div_id_user_pick-address']);
+
 })();

--- a/noiseworks/forms.py
+++ b/noiseworks/forms.py
@@ -1,5 +1,22 @@
+from datetime import date
+from django.core.validators import ValidationError
 from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.fields import DateInputField
 from crispy_forms_gds.layout import Submit
+
+
+def monkeypatch(self, data_list):
+    day, month, year = data_list
+    if day and month and year:
+        try:
+            return date(day=int(day), month=int(month), year=int(year))
+        except ValueError as e:
+            raise ValidationError(str(e)) from e
+    else:  # pragma: no cover
+        return None
+
+
+DateInputField.compress = monkeypatch
 
 
 class GDSForm:

--- a/noiseworks/settings.py
+++ b/noiseworks/settings.py
@@ -78,6 +78,7 @@ CRISPY_CLASS_CONVERTERS = {
     "select": "govuk-select lbh-select",
     "textinput": "govuk-input lbh-input",
     "emailinput": "govuk-input lbh-input",
+    "timewidget": "govuk-input lbh-input govuk-input--width-5",
     "textarea": "govuk-textarea lbh-textarea",
     "clearablefileinput": "govuk-file-upload lbh-file-upload",
     "searchwidget": "govuk-input lbh-input",
@@ -183,6 +184,17 @@ USE_I18N = True
 
 USE_L10N = False
 DATETIME_FORMAT = "D, j M Y, P"
+DATE_FORMAT = "D, j M Y"
+TIME_INPUT_FORMATS = [
+    "%I:%M %p",
+    "%I.%M %p",
+    "%I %M %p",
+    "%I:%M%p",
+    "%I.%M%p",
+    "%I %M%p",
+    "%I %p",
+    "%I%p",
+]
 
 USE_TZ = True
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -264,6 +264,17 @@ python-versions = ">=3.5"
 Django = ">=2.2"
 
 [[package]]
+name = "django-formtools"
+version = "2.3"
+description = "A set of high-level abstractions for Django forms"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+Django = ">=2.2"
+
+[[package]]
 name = "django-libsass"
 version = "0.8"
 description = "A django-compressor filter to compile SASS files using libsass"
@@ -658,7 +669,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "bee2eafd66816d85226ce49e1f96e6f5de985ef2b58e1c979877047be6326964"
+content-hash = "5212ee8ee6ab29cc54de74a7b6402bc8278c41dc8a0289f91e1c27df461dd313"
 
 [metadata.files]
 appdirs = [
@@ -855,6 +866,10 @@ django-environ = [
 django-filter = [
     {file = "django-filter-2.4.0.tar.gz", hash = "sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06"},
     {file = "django_filter-2.4.0-py3-none-any.whl", hash = "sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1"},
+]
+django-formtools = [
+    {file = "django-formtools-2.3.tar.gz", hash = "sha256:9663b6eca64777b68d6d4142efad8597fe9a685924673b25aa8a1dcff4db00c3"},
+    {file = "django_formtools-2.3-py3-none-any.whl", hash = "sha256:4699937e19ee041d803943714fe0c1c7ad4cab802600eb64bbf4cdd0a1bfe7d9"},
 ]
 django-libsass = [
     {file = "django-libsass-0.8.tar.gz", hash = "sha256:38fab4ce1245542f3afd7248dc48f8a0b261f5f6c61e7cc43969a9c9079b5ffd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requests = "^2.25.1"
 django-sesame = "^2.4"
 django-phonenumber-field = {extras = ["phonenumberslite"], version = "^5.2.0"}
 notifications-python-client = "^6.2.0"
+django-formtools = "^2.3"
 
 [tool.poetry.dev-dependencies]
 black = "^21.5b1"


### PR DESCRIPTION
[Will need to rebuild docker to get new python package]

This adds a recurrence diary-log form - usable by staff or normal users with a complaint on a case, but button only on staff pages in this PR.

Updates the Complaint model to use the new fields needed by the recurrence prototype - note this migration isn't backwards compatible (as it drops the old columns), so you might have to recreate your database if you try out this branch.

Note animation below is out of date, date/time fields are much better now, and there's the whole user thing I've done since thing. I should have done a new animation.

<img src="https://user-images.githubusercontent.com/154364/141476293-6b9e138b-a6dc-4c27-b937-2e7c9e992e38.gif" width="50%">

