### PR TITLE
Added dropdown "Cases location" for the filter section in the cases form

### DIFF
--- a/cases/templates/cases/case_list_staff.html
+++ b/cases/templates/cases/case_list_staff.html
@@ -13,6 +13,10 @@
         {% crispy filter.form %}
         </div>
     </div>
+    <script>
+        var nw = nw || {};
+        nw.user_wards = {{ user_wards|safe }};
+    </script>
     <div class="govuk-grid-column-two-thirds">
 
       {% if qs %}

--- a/cases/tests/test_filters.py
+++ b/cases/tests/test_filters.py
@@ -83,3 +83,8 @@ def test_search(admin_client, case_1, requests_mock):
     assertContains(resp, "Other")
     resp = admin_client.get(f"/cases?search={case_1.id}")
     assertContains(resp, "Other")
+
+
+def test_user_ward_js_array(admin_client):
+    resp = admin_client.get(f"/cases")
+    assertContains(resp, "nw.user_wards = []")

--- a/cases/tests/test_reporting.py
+++ b/cases/tests/test_reporting.py
@@ -109,7 +109,7 @@ def test_staff_case_creation(admin_client, normal_user, mocks):
     assertContains(resp, "A shop, bar, nightclub")
     assertContains(resp, "Line 1, Line 2, Line 3")
     today = datetime.date.today()
-    assertContains(resp, f"{today.strftime('%a, %d %b %Y')}, 9 p.m.")
+    assertContains(resp, f"{today.strftime('%a, %-d %b %Y')}, 9 p.m.")
     post_step("summary", {"true_statement": 1}, follow=True)
     assert Case.objects.count() == 1
     assert Complaint.objects.count() == 1
@@ -208,7 +208,7 @@ def test_user_case_creation(client, normal_user, mocks):
     assertContains(resp, "A shop, bar, nightclub")
     assertContains(resp, "180m around (536926,124099)")
     today = datetime.date.today()
-    assertContains(resp, f"{today.strftime('%a, %d %b %Y')}, 9 p.m.")
+    assertContains(resp, f"{today.strftime('%a, %-d %b %Y')}, 9 p.m.")
     post_step("summary", {"true_statement": 1}, follow=True)
 
 

--- a/cases/views.py
+++ b/cases/views.py
@@ -66,6 +66,7 @@ def case_list_staff(request):
         {
             "filter": f,
             "qs": qs,
+            "user_wards": request.user.wards or [],
         },
     )
 

--- a/cobrand_hackney/static/js.js
+++ b/cobrand_hackney/static/js.js
@@ -70,4 +70,103 @@ show_hide("kind-kind", "other", ["div_id_kind-kind_other"]);
 show_hide("where-where", "residence", ["div_id_where-estate"]);
 show_hide("user_pick-user", "0", ['div_id_user_pick-first_name', 'div_id_user_pick-last_name', 'div_id_user_pick-email', 'div_id_user_pick-phone', 'div_id_user_pick-address']);
 
+// Creating a new dropdown "Case Locations"
+construct_case_locations_dropdown();
+
 })();
+
+// ---
+
+function same_contents(a, b) {
+    var checked_values = [];
+    a.forEach(function(i) { checked_values.push(i.value); });
+    checked_values.sort();
+    var user_wards = [];
+    b.forEach(function(i) { user_wards.push(i); });
+    user_wards.sort();
+    for (var i=0; i<checked_values.length; i++) {
+        if (checked_values[i] !== user_wards[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function construct_case_locations_dropdown() {
+    var inputs = document.querySelectorAll('.govuk-checkboxes__input[name=ward][type=checkbox]');
+
+    var my_cases_option = '';
+    if (nw.user_wards.length) {
+        var area_names = [];
+        for (var i = 0; i < inputs.length; i++) {
+            if (nw.user_wards.indexOf(inputs[i].value) > -1) {
+                var label = document.querySelector('label[for=' + inputs[i].id + ']');
+                area_names.push(label.innerText);
+            }
+        }
+        area_names = area_names.join(', ');
+        var area_label = 'My areas';
+        if (area_names) {
+            area_label += ' (' + area_names + ')';
+        }
+        my_cases_option = '<option value="my_areas">' + area_label + '</option>';
+    }
+    var caseLocationDiv = document.createElement('div');
+    caseLocationDiv.className = 'govuk-form-group lbh-form-group';
+    caseLocationDiv.id = 'div_id_case_location';
+    caseLocationDiv.innerHTML = '<label for="id_case_location" class="govuk-label lbh-label">Case location</label>' + '<select class="govuk-select lbh-select" id="id_case_location"> <option value="all_areas" selected>All areas</option>' + my_cases_option + '<option value="selected_areas">Selected areas</option> <option value="outside_hackney">Outside Hackney</option> </select> ';
+
+    // Defining the div that contains all the ward checkboxes
+    var area = document.getElementById("div_id_ward");
+
+    // Locating "Case Locations" before the area
+    parentFormNode = area.parentNode;
+    parentFormNode.insertBefore(caseLocationDiv, area);
+
+    // Defining the rest of the variables
+    var inputArea = document.getElementById("id_case_location");
+    var outsideHackney = document.querySelector('input[name="ward"][value="outside"]');
+    var myAreasCheckboxChecked = document.querySelectorAll('.govuk-checkboxes__input:checked');
+    var myAreasCheckbox = document.querySelectorAll('.govuk-checkboxes__input');
+    area.style.display = "none";
+
+    // Whenever there is at least one checkbox checked the filter will select by default "selected areas"
+    // and will display all the checkboxes.
+    if (outsideHackney.checked == true && myAreasCheckboxChecked.length == 1) {
+        inputArea.value = 'outside_hackney';
+    } else if (myAreasCheckboxChecked.length == myAreasCheckbox.length || myAreasCheckboxChecked.length == 0 ) {
+        inputArea.value = 'all_areas';
+    } else if (myAreasCheckboxChecked.length == nw.user_wards.length && same_contents(myAreasCheckboxChecked, nw.user_wards)) {
+        inputArea.value = 'my_areas';
+    } else {
+        inputArea.value = 'selected_areas';
+        area.style.display = "block";
+    }
+
+    inputArea.addEventListener('change',function(){
+        area.style.display = "none";
+        if (inputArea.value == 'all_areas') {
+            // all the checkboxes for areas will be clicked
+            for (var i = 0; i < inputs.length; i++) {
+                inputs[i].checked = false;
+            }
+        } else if (inputArea.value =="outside_hackney") {
+            // Outside hackney
+            for (var i = 0; i < inputs.length; i++) {
+                inputs[i].checked = false;
+            }
+            outsideHackney.checked = true;
+        } else if (inputArea.value == 'selected_areas') {
+            // selected areas. The checkboxes will become unchecked
+            for (var i = 0; i < inputs.length; i++) {
+                inputs[i].checked = false;
+            }
+            area.style.display = "block";
+        } else if (inputArea.value == 'my_areas') {
+            for (var i = 0; i < inputs.length; i++) {
+                var my_area = nw.user_wards.indexOf(inputs[i].value) > -1;
+                inputs[i].checked = my_area;
+            }
+        }
+    });
+}


### PR DESCRIPTION
This commit fixes the permanent visibility issue of "Area" checkboxes in the cases form. Which was causing some UX issues due to the current number of checkboxes.

To fix this issue there is a new dropdown "Case location"
just above "Area" checkboxes. Currently it has three options:
- All areas(Default): which will search in all areas.(Area checkboxes will remain hidden)
- Selected Areas: This option will display all the checkboxes allowing the user to pick areas.
- Outside Hackney: Will check the checkbox "Outside Hackney". (Area checkboxes will remain hidden)


https://user-images.githubusercontent.com/13790153/141788270-a7c87a94-a854-40bb-9561-e8d4688b9b50.mov

Fixes part of the issue: https://github.com/mysociety/noiseworks/issues/53