### PR TITLE
Disable scroll wheel zoom on case detail page map

### DIFF
--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -151,7 +151,8 @@ var nw = nw || {};
     var point = new L.LatLng({{ case.point_as_latlon_string }});
     var map = nw.map = new L.Map("leaflet", {
         center: point,
-        zoom: 17
+        zoom: 17,
+        scrollWheelZoom: false
     });
     map.zoomControl.setPosition('topright');
     map.attributionControl.setPrefix('');


### PR DESCRIPTION
The map on the case detail page is almost full width, making it hard to scroll past if scroll wheel zooming is enabled. There are +/- buttons to control zooming, so it’s only a minor inconvenience to disable scroll wheel zooming, but a big win for quickly moving around the page.

Fixes #51.