### PR TITLE
Tidy up spacing of footer elements

### DIFF
--- a/accounts/templates/accounts/form_signin.html
+++ b/accounts/templates/accounts/form_signin.html
@@ -8,7 +8,9 @@
 {% error_summary form %}
 {% crispy form %}
 
-<a href="{% url "oauth:authenticate" %}">Hackney Staff Sign-in</a>
+<aside class="nw-staff-signin">
+    <a href="{% url "oauth:authenticate" %}">Hackney Staff Sign-in</a>
+</aside>
 
 {% endblock %}
 

--- a/cobrand_hackney/static/app.scss
+++ b/cobrand_hackney/static/app.scss
@@ -89,6 +89,7 @@ footer {
     background-color: lbh-colour("lbh-primary-hover");
     color: #fff;
     padding: govuk-spacing(6);
+    margin-top: 0;
 }
 
 .noiseworks-footer {

--- a/cobrand_hackney/static/app.scss
+++ b/cobrand_hackney/static/app.scss
@@ -278,3 +278,7 @@ ul.case-list-user li {
         }
     }
 }
+
+.nw-staff-signin {
+    margin-top: govuk-spacing(9);
+}

--- a/cobrand_hackney/static/app.scss
+++ b/cobrand_hackney/static/app.scss
@@ -90,12 +90,19 @@ footer {
     color: #fff;
     padding: govuk-spacing(6);
 }
+
 .noiseworks-footer {
-    text-align: right;
+    font-family: $lbh-font-family;
+    margin-top: 1rem;
+
+    @include govuk-media-query($from: tablet) {
+        text-align: right;
+        margin-top: 0.3rem; // vertically centred in footer, alongside Hackney logo
+    }
 }
 
 a.platform-logo {
-    vertical-align: middle;
+    vertical-align: -0.8em;
     display: inline-block;
     background-position: top left;
     background-repeat: no-repeat;
@@ -105,7 +112,7 @@ a.platform-logo {
     height: 0;
     padding-top: 2em;
     overflow: hidden;
-    margin-left: 0.25em;
+    margin-left: 0.5em;
     padding-right: 0.25em;
 }
 

--- a/cobrand_hackney/templates/home_unapproved.html
+++ b/cobrand_hackney/templates/home_unapproved.html
@@ -7,6 +7,8 @@
 <p>Only approved Hackney accounts can access this system.
 Please contact your manager if you require access.</p>
 
-<p><a href="{% url "oauth:authenticate" %}">Hackney Staff Sign-in</a></p>
+<aside class="nw-staff-signin">
+    <a href="{% url "oauth:authenticate" %}">Hackney Staff Sign-in</a>
+</aside>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #62.

"Powered by NoiseWorks" badge in footer now has the correct font-family, and is nicely spaced at both mobile and desktop widths.

"Hackney Staff Sign-in" links now have some vertical space, to separate them from the content above.

And I removed the extraneous margin-top on the site footer, since the content wrapper adds its own padding-bottom, so there was no need.

# mobile

![Screen Shot 2022-01-08 at 09 10 46](https://user-images.githubusercontent.com/739624/148638741-af7243a9-d8c0-4815-a3b8-8fa332e118b0.png)

# desktop

![Screen Shot 2022-01-08 at 09 10 33](https://user-images.githubusercontent.com/739624/148638745-a68ed659-3a44-415a-91bb-cc65f719130a.png)

