### PR TITLE
Timeline improvements

### DIFF
--- a/cases/templates/cases/_complaint_summary.html
+++ b/cases/templates/cases/_complaint_summary.html
@@ -1,0 +1,35 @@
+<dl class="nw-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Complaint created
+    <dd class="govuk-summary-list__value">{{ complaint.created }}
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Complainant
+    <dd class="govuk-summary-list__value">{{ complaint.complainant }}
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Noise started</dt>
+    <dd class="govuk-summary-list__value">{{ complaint.start }}</dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Ended</dt>
+    <dd class="govuk-summary-list__value">
+    {% if complaint.happening_now %}
+        Still ongoing at
+    {% endif %}
+      {{ complaint.end }}
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Rooms affected
+    <dd class="govuk-summary-list__value">{{ complaint.rooms }}
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Noise description
+    <dd class="govuk-summary-list__value">{{ complaint.description }}
+  </div>
+  <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
+    <dt class="govuk-summary-list__key">Effect of noise
+    <dd class="govuk-summary-list__value">{{ complaint.effect }}
+  </div>
+</dl>

--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -277,15 +277,7 @@ var nw = nw || {};
               <span class="govuk-details__summary-text"> Complaint details </span>
             </summary>
             <div class="govuk-details__text">
-                {{ entry.complaint.happening_now|yesno:"Happening now,Not happening now" }},
-                {% if entry.complaint.happening_now %}
-                    started {{ entry.complaint.start }}.
-                {% else %}
-                    {{ entry.complaint.start }} – {{ entry.complaint.end }}.
-                {% endif %}
-                Rooms: {{ entry.complaint.rooms }},
-                description: {{ entry.complaint.description }},
-                effect: {{ entry.complaint.effect }}.
+              {% include "cases/_complaint_summary.html" with complaint=entry.complaint %}
             </div>
           </details>
 

--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -303,7 +303,7 @@ var nw = nw || {};
         {% endif %}
 
     {% endif %}
-    <p class="lbh-body-m">{{ entry.time }}</p>
+    <p class="lbh-body-s govuk-!-margin-top-1">{{ entry.time }}</p>
 </li>
 {% endfor %}
 </ol>

--- a/cases/templates/cases/complaint_detail.html
+++ b/cases/templates/cases/complaint_detail.html
@@ -11,40 +11,6 @@
 
 <h2>Complaint info</h2>
 
-<dl class="nw-summary-list">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Complaint created
-    <dd class="govuk-summary-list__value">{{ complaint.created }}
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Complainant
-    <dd class="govuk-summary-list__value">{{ complaint.complainant }}
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Noise started</dt>
-    <dd class="govuk-summary-list__value">{{ complaint.start }}</dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Ended</dt>
-    <dd class="govuk-summary-list__value">
-    {% if complaint.happening_now %}
-        Still ongoing at
-    {% endif %}
-      {{ complaint.end }}
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Rooms affected
-    <dd class="govuk-summary-list__value">{{ complaint.rooms }}
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Noise description
-    <dd class="govuk-summary-list__value">{{ complaint.description }}
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Effect of noise
-    <dd class="govuk-summary-list__value">{{ complaint.effect }}
-  </div>
-</dl>
+{% include "cases/_complaint_summary.html" with complaint=complaint %}
 
 {% endblock %}

--- a/cobrand_hackney/static/_timeline.scss
+++ b/cobrand_hackney/static/_timeline.scss
@@ -10,6 +10,10 @@
     margin-top: 0;
 }
 
+.lbh-timeline__event {
+    padding-bottom: govuk-spacing(6);
+}
+
 .case-numbers {
     background-color: lbh-colour("lbh-grey-3");
     display: inline-block;

--- a/cobrand_hackney/static/_timeline.scss
+++ b/cobrand_hackney/static/_timeline.scss
@@ -42,4 +42,9 @@
         font-size: 0.9em;
         border-radius: 0.25em;
     }
+
+    .govuk-summary-list,
+    .nw-summary-list {
+        font-size: 1em;
+    }
 }


### PR DESCRIPTION
A couple of improvements suggested as a result of the recent user testing.

<img width="1040" alt="Screenshot 2022-01-08 at 16 18 37" src="https://user-images.githubusercontent.com/739624/148651569-410d1b98-0a02-49b6-9b04-60f6d15b6737.png">
