### PR TITLE
Simplify case filter logic

### DIFF
--- a/cases/filters.py
+++ b/cases/filters.py
@@ -48,23 +48,13 @@ class CaseFilter(django_filters.FilterSet):
         data = data.copy()
         user = kwargs["request"].user
         submitted = data.get("kind") is not None
-        # If the user has associated wards, and we've been asked for all/unassigned/others
-        # (but not via a filter form submission), use those wards by default
-        if (
-            user.wards
-            and not submitted
-            and data.get("assigned") in ("", "none", "others")
-        ):
-            data.setlistdefault("ward", user.wards)
-        # Default to showing cases assigned to the user
-        data.setdefault("assigned", "me")
         super().__init__(data, *args, **kwargs)
         self.filters.move_to_end("search", last=False)
         self.filters["kind"].label = "Noise type"
         self.filters["where"].label = "Noise location type"
         self.filters["estate"].label = "Hackney Estates property?"
         try:
-            user = User.objects.get(id=data["assigned"])
+            user = User.objects.get(id=data.get("assigned", ""))
             self.filters["assigned"].extra["choices"].append((user.id, user))
         except (User.DoesNotExist, ValueError):
             pass

--- a/cases/templates/cases/_person.html
+++ b/cases/templates/cases/_person.html
@@ -9,7 +9,7 @@
 
     <h3>
       {% if person.email %}
-        <a href="{% url "cases" %}?assigned=&amp;search={{ person.email|urlencode }}">
+        <a href="{% url "cases" %}?search={{ person.email|urlencode }}">
       {% endif %}
         {{ person.first_name }}
         {{ person.last_name }}

--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -119,7 +119,7 @@
       <dt class="govuk-summary-list__key">Address</dt>
       <dd class="govuk-summary-list__value">
         {% if case.uprn %}
-            <a href="{% url "cases" %}?assigned=&amp;uprn={{ case.uprn }}">{{ case.location_display }}</a>
+            <a href="{% url "cases" %}?uprn={{ case.uprn }}">{{ case.location_display }}</a>
         {% else %}
             {{ case.location_display }}
         {% endif %}
@@ -165,7 +165,7 @@
   {% endif %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Ward</dt>
-      <dd class="govuk-summary-list__value"><a href="{% url "cases" %}?assigned=&amp;ward={{ case.ward }}">{{ case.get_ward_display }}</a></dd>
+      <dd class="govuk-summary-list__value"><a href="{% url "cases" %}?ward={{ case.ward }}">{{ case.get_ward_display }}</a></dd>
       <dd class="govuk-summary-list__actions"></dd>
     </div>
 

--- a/cases/templates/cases/case_list_staff.html
+++ b/cases/templates/cases/case_list_staff.html
@@ -31,7 +31,7 @@
     <li class="nw-case-list__empty">
         <p>There are no cases assigned to you.</p>
         <p><a class="nw-link--no-visited-state" href="{% url "cases" %}?assigned=none">Show unassigned cases</a>
-        <p><a class="nw-link--no-visited-state" href="{% url "cases" %}?assigned=">Show all cases</a>
+        <p><a class="nw-link--no-visited-state" href="{% url "cases" %}">Show all cases</a>
     </li>
   {% else %}
     <li><p>There are no cases to show.</p></li>

--- a/cases/templates/cases/merged_start.html
+++ b/cases/templates/cases/merged_start.html
@@ -22,9 +22,9 @@
 </div>
 
 {% if cases_same_uprn or cases_nearby %}
-    <p>Select a case to merge into, from the suggestions below, or <a class="nw-link--no-visited-state" href="{% url "cases" %}?assigned=">the list of all cases</a></p>
+    <p>Select a case to merge into, from the suggestions below, or <a class="nw-link--no-visited-state" href="{% url "cases" %}">the list of all cases</a></p>
 {% else %}
-    <p>Select a case to merge into, from <a class="nw-link--no-visited-state" href="{% url "cases" %}?assigned=">the list of all cases</a></p>
+    <p>Select a case to merge into, from <a class="nw-link--no-visited-state" href="{% url "cases" %}">the list of all cases</a></p>
 {% endif %}
 
 {% if case.uprn and cases_same_uprn %}

--- a/cases/tests/test_filters.py
+++ b/cases/tests/test_filters.py
@@ -53,7 +53,7 @@ def test_assigned_filter(admin_client, admin_user, case_1, case_location):
     assertContains(response, f"/cases/{case_1.id}")
     case_1.assigned = admin_user
     case_1.save()
-    response = admin_client.get("/cases")
+    response = admin_client.get("/cases?assigned=me")
     assertContains(response, f"/cases/{case_1.id}")
     response = admin_client.get(f"/cases?assigned={admin_user.id}")
     assertContains(response, f"/cases/{case_1.id}")
@@ -69,18 +69,22 @@ def test_assigned_filter(admin_client, admin_user, case_1, case_location):
 def test_ward_filter(admin_client, admin_user, case_1):
     admin_user.wards = ["E05009374"]
     admin_user.save()
-    response = admin_client.get("/cases?assigned=")
+    response = admin_client.get(
+        "/cases?" + "&".join(f"ward={ward}" for ward in admin_user.wards)
+    )
     assertNotContains(response, f"/cases/{case_1.id}")
     admin_user.wards = ["E05009372", case_1.ward]
     admin_user.save()
-    response = admin_client.get("/cases?assigned=")
+    response = admin_client.get(
+        "/cases?" + "&".join(f"ward={ward}" for ward in admin_user.wards)
+    )
     assertContains(response, f"/cases/{case_1.id}")
 
 
 def test_search(admin_client, case_1):
-    resp = admin_client.get("/cases?assigned=&search=fireworks")
+    resp = admin_client.get("/cases?search=fireworks")
     assertContains(resp, "Fireworks")
-    resp = admin_client.get(f"/cases?assigned=&search={case_1.id}")
+    resp = admin_client.get(f"/cases?search={case_1.id}")
     assertContains(resp, "Fireworks")
 
 
@@ -88,7 +92,7 @@ def test_search_phone(admin_client, case_1):
     Complaint.objects.create(
         case=case_1, complainant=case_1.created_by, happening_now=True
     )
-    resp = admin_client.get(f"/cases?assigned=&search=07900000000")
+    resp = admin_client.get(f"/cases?search=07900000000")
     assertContains(resp, "Fireworks")
 
 
@@ -96,7 +100,7 @@ def test_search_name(admin_client, case_1):
     Complaint.objects.create(
         case=case_1, complainant=case_1.created_by, happening_now=True
     )
-    resp = admin_client.get(f"/cases?assigned=&search=Normal+User")
+    resp = admin_client.get(f"/cases?search=Normal+User")
     assertContains(resp, "Fireworks")
 
 

--- a/cases/tests/tests.py
+++ b/cases/tests/tests.py
@@ -97,7 +97,7 @@ def test_case_uprn(admin_client, case_other_uprn):
     response = admin_client.get(f"/cases/{case_other_uprn.id}")
     assertContains(response, "Wombat")
     assertContains(response, "Flat 4, 2 Example Road")
-    response = admin_client.get(f"/cases?assigned=&uprn=10001")
+    response = admin_client.get(f"/cases?uprn=10001")
     assertContains(response, "Flat 4, 2 Example Road")
 
 

--- a/cobrand_hackney/static/_forms.scss
+++ b/cobrand_hackney/static/_forms.scss
@@ -38,3 +38,15 @@
     margin-top: -6px;
     margin-top: -0.375rem
 }
+
+// No need for visible "Area" fieldset legend when the "Case location"
+// select box has been inserted before it, by JavaScript.
+#div_id_case_location + #div_id_ward {
+    .govuk-fieldset__legend {
+        @extend .govuk-visually-hidden;
+    }
+
+    .govuk-checkboxes {
+        margin-top: 0;
+    }
+}

--- a/cobrand_hackney/static/js.js
+++ b/cobrand_hackney/static/js.js
@@ -110,7 +110,7 @@ function construct_case_locations_dropdown() {
             }
         }
         area_names = area_names.join(', ');
-        var area_label = 'My areas';
+        var area_label = 'My wards';
         if (area_names) {
             area_label += ' (' + area_names + ')';
         }
@@ -119,7 +119,7 @@ function construct_case_locations_dropdown() {
     var caseLocationDiv = document.createElement('div');
     caseLocationDiv.className = 'govuk-form-group lbh-form-group';
     caseLocationDiv.id = 'div_id_case_location';
-    caseLocationDiv.innerHTML = '<label for="id_case_location" class="govuk-label lbh-label">Case location</label>' + '<select class="govuk-select lbh-select" id="id_case_location"> <option value="all_areas" selected>All areas</option>' + my_cases_option + '<option value="selected_areas">Selected areas</option> <option value="outside_hackney">Outside Hackney</option> </select> ';
+    caseLocationDiv.innerHTML = '<label for="id_case_location" class="govuk-label lbh-label">Case location</label>' + '<select class="govuk-select lbh-select" id="id_case_location"> <option value="all_areas" selected>All wards</option>' + my_cases_option + '<option value="selected_areas">Selected wards</option> <option value="outside_hackney">Outside Hackney</option> </select> ';
 
     // Defining the div that contains all the ward checkboxes
     var area = document.getElementById("div_id_ward");

--- a/cobrand_hackney/templates/base.html
+++ b/cobrand_hackney/templates/base.html
@@ -125,8 +125,11 @@
       </div>
       <div class="lbh-header__links">
         {% if request.user.is_staff %}
-          <a href="{% url "cases" %}?assigned=me">My cases</a>
           <a href="{% url "cases" %}">All cases</a>
+          <a href="{% url "cases" %}?assigned=me">My cases</a>
+        {% if request.user.wards %}
+          <a href="{% url "cases" %}{% for w in request.user.wards %}{% if forloop.first %}?{% else %}&amp;{% endif %}ward={{ w }}{% endfor %}">My ward{{ request.user.wards|length|pluralize }}</a>
+        {% endif %}
           <a href="{% url "case-add" %}">New case</a>
         {% else %}
           <a href="{% url "cases" %}?assigned=me">My cases</a>

--- a/cobrand_hackney/templates/base.html
+++ b/cobrand_hackney/templates/base.html
@@ -125,11 +125,11 @@
       </div>
       <div class="lbh-header__links">
         {% if request.user.is_staff %}
-          <a href="{% url "cases" %}">My cases</a>
-          <a href="{% url "cases" %}?assigned=">All cases</a>
+          <a href="{% url "cases" %}?assigned=me">My cases</a>
+          <a href="{% url "cases" %}">All cases</a>
           <a href="{% url "case-add" %}">New case</a>
         {% else %}
-          <a href="{% url "cases" %}">My cases</a>
+          <a href="{% url "cases" %}?assigned=me">My cases</a>
           <a href="{% url "case-add-intro" %}">New case</a>
         {% endif %}
         {% if request.user.is_authenticated %}

--- a/noiseworks/templates/_base.html
+++ b/noiseworks/templates/_base.html
@@ -59,8 +59,8 @@
     <nav id="main-nav" role="navigation">
 
     <ul class="nav-menu nav-menu--main">
-        <li><a href="{% url "cases" %}">My cases</a></li>
-        <li><a href="{% url "cases" %}?assigned=">All cases</a></li>
+        <li><a href="{% url "cases" %}?assigned=me">My cases</a></li>
+        <li><a href="{% url "cases" %}">All cases</a></li>
         <!-- <li><a href="">New case</a></li> -->
         <!-- <li><a href="">Dashboard</li> -->
       {% if user and user.is_staff %}


### PR DESCRIPTION
WIP – tests need fixing.

Fixes #85.

@dracos does this make sense to you? What we’re trying to avoid is people being surprised by the case list not including things they expected to be there. As we’ve talked to more officers, it’s become clearer that they _do_ often want to see cases outside their own wards, so it’s a lot less cut and dry than we previously thought. Seems the safest thing to do is give them clear, unsurprising links in the nav bar, and let them do what they want.