### PR TITLE
Improve/consolidate staff user picking.

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -38,6 +38,19 @@ class UserManager(BaseManager):
         )
         return user
 
+    def check_existing(self, email=None, phone=None):
+        if email:
+            try:
+                return User.objects.get(email=email, email_verified=True)
+            except User.DoesNotExist:
+                pass
+        if phone:
+            try:
+                return User.objects.get(phone=phone, phone_verified=True)
+            except User.DoesNotExist:
+                pass
+        return None
+
 
 class User(AbstractUser):
     BEST_METHOD_CHOICES = [

--- a/cases/tests/test_perpetrators.py
+++ b/cases/tests/test_perpetrators.py
@@ -56,25 +56,20 @@ def test_add_perpetrator(admin_client, case_1, normal_user, normal_user_2):
         f"/cases/{case_1.id}/add-perpetrator",
         {"search": "normal", "user": normal_user.id},
     )
+    params = {"search": "normal", "user": 0, "first_name": "Normal"}
+    resp = admin_client.post(
+        f"/cases/{case_1.id}/add-perpetrator",
+        {**params, "last_name": "User2", "email": "normal2@example.org"},
+        follow=True,
+    )
+    assertContains(resp, "There is an existing user")
     admin_client.post(
         f"/cases/{case_1.id}/add-perpetrator",
-        {
-            "search": "normal",
-            "user": 0,
-            "first_name": "Normal",
-            "last_name": "User3",
-            "email": "normal3@example.org",
-        },
+        {**params, "last_name": "User3", "email": "normal3@example.org"},
     )
     admin_client.post(
         f"/cases/{case_1.id}/add-perpetrator",
-        {
-            "search": "normal",
-            "user": 0,
-            "first_name": "Normal",
-            "last_name": "User4",
-            "phone": "07900000000",
-        },
+        {**params, "last_name": "User4", "phone": "07900000000"},
     )
 
 

--- a/cases/tests/test_recurrence.py
+++ b/cases/tests/test_recurrence.py
@@ -127,17 +127,17 @@ def _test_add_complaint_not_now_new_user(admin_client, case_1, normal_user, user
 
     resp = post_step("user_pick", {"user_pick-search": "Normal", "user_pick-user": 0})
     assertContains(resp, "Please specify a name")
+    params = {
+        "user_pick-search": "Normal",
+        "user_pick-user": 0,
+        "user_pick-first_name": "Norman",
+        "user_pick-last_name": "Normal",
+    }
     resp = post_step(
-        "user_pick",
-        {
-            "user_pick-search": "Normal",
-            "user_pick-user": 0,
-            "user_pick-first_name": "Norman",
-            "user_pick-last_name": "Normal",
-            **user_data,
-        },
-        follow=True,
+        "user_pick", {**params, "user_pick-email": normal_user.email}, follow=True
     )
+    assertContains(resp, "There is an existing user")
+    resp = post_step("user_pick", {**params, **user_data}, follow=True)
     assertContains(resp, "Fri, 12 Nov 2021, 9 p.m.")
     assertContains(resp, "Fri, 12 Nov 2021, 10 p.m.")
     assertContains(resp, "Norman Normal")


### PR DESCRIPTION
Before 61bd377 the perpetrator or reoccurence code would create a second verified-email account with the same email, which would then cause issues. 61bd377 added an uniqueness index so that couldn't happen in the DB, but then threw an error when the code tried to insert it. This commit changes the pick form to check if newly entered user data matches an existing account and inform the user if so. Reoccurrence/reporting now also uses more of the same code for user handling.