### PR TITLE
Post live fixes 2

### DIFF
--- a/cases/forms/person.py
+++ b/cases/forms/person.py
@@ -24,13 +24,17 @@ class PersonPickForm(GDSForm, forms.Form):
         search = self.data.get("search") or self.initial.get("search")
         if search:
             search = search.lower()
-            choices = User.objects.filter(
+            queries = (
                 Q(first_name__icontains=search)
                 | Q(last_name__icontains=search)
                 | Q(address__icontains=search)
                 | Q(email__icontains=search)
                 | Q(phone__icontains=search)
             )
+            if " " in search:
+                f, l = search.split(maxsplit=1)
+                queries |= Q(first_name__icontains=f) & Q(last_name__icontains=l)
+            choices = User.objects.filter(queries)
             choices = list(map(lambda x: (x.id, str(x)), choices))
         else:
             choices = []

--- a/cases/forms/reporting.py
+++ b/cases/forms/reporting.py
@@ -126,7 +126,7 @@ class ReportingKindForm(StepForm):
         help_text="Please see <a href='https://hackney.gov.uk/noise' target='_blank'>https://hackney.gov.uk/noise</a> for the kinds of noise we can and can’t deal with.",
         choices=Case.KIND_CHOICES,
     )
-    kind_other = forms.CharField(label="Other", required=False)
+    kind_other = forms.CharField(label="Other", required=False, max_length=100)
 
     def clean(self):
         kind = self.cleaned_data.get("kind")

--- a/cases/tests/test_recurrence.py
+++ b/cases/tests/test_recurrence.py
@@ -90,10 +90,10 @@ def test_add_complaint_now_existing_user(admin_client, case_1, normal_user, staf
     post_step("describe", {"describe-description": "Desc"})
     post_step("effect", {"effect-effect": "Effect"})
 
-    post_step("user_search", {"user_search-search": "Normal"})
+    post_step("user_search", {"user_search-search": "Normal User"})
     resp = post_step(
         "user_pick",
-        {"user_pick-search": "Normal", "user_pick-user": normal_user.id},
+        {"user_pick-search": "Normal User", "user_pick-user": normal_user.id},
         follow=True,
     )
     assertContains(resp, f"{yesterday.strftime('%a, %-d %b %Y')}, 9 p.m.")

--- a/cases/tests/test_recurrence.py
+++ b/cases/tests/test_recurrence.py
@@ -201,6 +201,7 @@ def test_add_complaint_as_normal_user(
     assertContains(resp, "Sat, 13 Nov 2021, 1 a.m.")
 
     post_step("summary", {"summary-true_statement": 1}, follow=True)
+    resp = client.get(f"/cases/{case.id}/complaint/add/summary", follow=True)
 
     assert len(mail.outbox) == 2
     email = mail.outbox[0]

--- a/cases/tests/test_reporting.py
+++ b/cases/tests/test_reporting.py
@@ -230,6 +230,8 @@ def _test_user_case_creation(logged_in, client):
     post_step("address", {"addresses": "missing"})
     post_step("address", {"address_uprn": "10008315925"})
     post_step("kind", {"kind": "other"})
+    resp = post_step("kind", {"kind": "other", "kind_other": "Other " * 20})
+    assertContains(resp, "at most 100 characters")
     post_step("kind", {"kind": "other", "kind_other": "Other"})
     post_step("where", {"where": "residence", "estate": "n"})
     post_step("where-location", {"search": "Foobar1"})

--- a/cases/tests/test_reporting.py
+++ b/cases/tests/test_reporting.py
@@ -148,6 +148,7 @@ def test_staff_case_creation(admin_client, normal_user, mocks):
     assert Complaint.objects.count() == 1
     normal_user.refresh_from_db()
     assert normal_user.first_name == "Normal"
+    admin_client.get(f"/cases/add/summary")
 
 
 def test_staff_case_creation_new_user_map(admin_client, admin_user, normal_user, mocks):
@@ -270,6 +271,9 @@ def _test_user_case_creation(logged_in, client):
         assertContains(resp, "Incorrect or expired code")
         resp = post_step("confirmation", {"code": str(code).zfill(6)}, follow=True)
     assertContains(resp, "Thank you for reporting")
+    client.get(
+        f"/cases/add/address"
+    )  # Test fetching this page after submission does not error
 
     assert len(mail.outbox) == 2
     for r in range(2):


### PR DESCRIPTION
A fix for visit to summary pages after the end of the process (when it would error as the data was no longer there to show), and an improvement to staff user searching during the reporting process (same change already made to cases filter).