### PR TITLE
User editing tweaks

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -99,20 +99,16 @@ class CodeForm(GDSForm, forms.Form):
         self.user = user
 
 
-def get_wards():
-    wards = cobrand.api.wards()
-    wards = {ward["gss"]: ward["name"] for ward in wards}
-    return list(wards.items())
-
-
-class EditForm(GDSForm, forms.ModelForm):
+class EditUserForm(GDSForm, forms.ModelForm):
     best_time = forms.MultipleChoiceField(
         choices=User.BEST_TIME_CHOICES,
         widget=forms.CheckboxSelectMultiple,
         required=False,
     )
-    wards = forms.MultipleChoiceField(
-        choices=get_wards, widget=forms.CheckboxSelectMultiple, required=False
+    best_method = forms.ChoiceField(
+        choices=User.BEST_METHOD_CHOICES + [("", "Unknown")],
+        widget=forms.RadioSelect,
+        required=False,
     )
 
     class Meta:
@@ -128,5 +124,28 @@ class EditForm(GDSForm, forms.ModelForm):
             "address",
             "best_time",
             "best_method",
+        )
+
+
+def get_wards():
+    wards = cobrand.api.wards()
+    wards = {ward["gss"]: ward["name"] for ward in wards}
+    return list(wards.items())
+
+
+class EditStaffForm(GDSForm, forms.ModelForm):
+    wards = forms.MultipleChoiceField(
+        choices=get_wards, widget=forms.CheckboxSelectMultiple, required=False
+    )
+
+    class Meta:
+        model = User
+        fields = (
+            "first_name",
+            "last_name",
+            "email",
+            "email_verified",
+            "phone",
+            "phone_verified",
             "wards",
         )

--- a/accounts/templates/accounts/list.html
+++ b/accounts/templates/accounts/list.html
@@ -6,7 +6,7 @@
 
 <ul class="nw-list">
 {% for user in users %}
-<li>{% if request.user.is_superuser %}
+<li>{% if perms.accounts.change_user %}
     <a href="{% url "accounts:edit" user.id %}" class="nw-link--no-visited-state">{{ user }}</a> ({{ user.get_wards_display }})
     {% else %}
     {{ user }} ({{ user.get_wards_display }})

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -13,6 +13,11 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
+def normal_user(db):
+    return User.objects.create_user(email="user@example.org")
+
+
+@pytest.fixture
 def staff_user(db):
     return User.objects.create_user(
         is_staff=True, email="foo@example.org", wards=["E05009374"]
@@ -139,16 +144,12 @@ def test_log_in_by_code(client, non_staff_access):
     assert response.status_code == 302
 
 
-def test_basic_user_editing(admin_client, staff_user):
+def test_basic_user_editing(admin_client, normal_user):
     response = admin_client.get("/a/list")
-    response = admin_client.get(f"/a/{staff_user.id}/edit")
+    response = admin_client.get(f"/a/{normal_user.id}/edit")
     response = admin_client.post(
-        f"/a/{staff_user.id}/edit",
-        {
-            "best_time": ["weekday", "evening"],
-            "wards": ["E05009378", "E05009374"],
-            "best_method": "email",
-        },
+        f"/a/{normal_user.id}/edit",
+        {"best_time": ["weekday", "evening"], "best_method": "email"},
     )
     assert response.status_code == 302
     assert response.url == "/a/list"
@@ -157,11 +158,7 @@ def test_basic_user_editing(admin_client, staff_user):
 def test_edit_redirect_back_to_case(admin_client, staff_user):
     response = admin_client.post(
         f"/a/{staff_user.id}/edit?case=123",
-        {
-            "best_time": ["weekday", "evening"],
-            "wards": ["E05009378", "E05009374"],
-            "best_method": "email",
-        },
+        {"wards": ["E05009378", "E05009374"]},
     )
     assert response.status_code == 302
     assert response.url == "/cases/123"

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -98,7 +98,10 @@ def show_form(request):
 def edit(request, user_id):
     user = get_object_or_404(User, pk=user_id)
     if user.is_staff:
-        form = EditStaffForm(request.POST or None, instance=user)
+        if request.user.has_perm("accounts.change_user"):
+            form = EditStaffForm(request.POST or None, instance=user)
+        else:
+            raise PermissionDenied
     else:
         form = EditUserForm(request.POST or None, instance=user)
     if form.is_valid():

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -10,7 +10,7 @@ from sesame.utils import get_user
 from noiseworks.base32 import bytes_to_base32
 from noiseworks.decorators import staff_member_required
 from noiseworks.message import send_sms, send_email
-from .forms import SignInForm, CodeForm, EditForm
+from .forms import SignInForm, CodeForm, EditUserForm, EditStaffForm
 
 User = get_user_model()
 
@@ -97,7 +97,10 @@ def show_form(request):
 @staff_member_required
 def edit(request, user_id):
     user = get_object_or_404(User, pk=user_id)
-    form = EditForm(request.POST or None, instance=user)
+    if user.is_staff:
+        form = EditStaffForm(request.POST or None, instance=user)
+    else:
+        form = EditUserForm(request.POST or None, instance=user)
     if form.is_valid():
         form.save()
         if request.GET.get("case"):

--- a/noiseworks/admin.py
+++ b/noiseworks/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+
+
+class AdminSite(admin.AdminSite):
+    def has_permission(self, request):
+        return request.user.is_active and request.user.is_superuser

--- a/noiseworks/apps.py
+++ b/noiseworks/apps.py
@@ -1,0 +1,5 @@
+from django.contrib.admin.apps import AdminConfig
+
+
+class NWAdminConfig(AdminConfig):
+    default_site = "noiseworks.admin.AdminSite"

--- a/noiseworks/settings.py
+++ b/noiseworks/settings.py
@@ -55,7 +55,7 @@ INTERNAL_IPS = ["127.0.0.1"]
 COBRAND = env("COBRAND")
 
 INSTALLED_APPS = [
-    "django.contrib.admin",
+    "noiseworks.apps.NWAdminConfig",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",


### PR DESCRIPTION
Make the front end user edit form a bit nicer (slightly different for staff/non-staff user being edited), only allow staff with a permission to edit staff users. To do: allow staff with that permission to add new staff users, and toggle the staff flag of users; but this is enough for staff editing for now.
