### PR TITLE
Ignore already-merged cases in merging flow.

### DIFF
--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -3,7 +3,7 @@
 
 {% block merging %}
   {% with request.session.merging_case as duplicate %}
-    {% if duplicate and case.id != duplicate.id %}
+    {% if duplicate and case.id != duplicate.id and not case.merged_into %}
     <div class="lbh-merging-bar">
       <div class="lbh-container">
         <h5>Merging mode</h5>

--- a/cases/tests/test_merges.py
+++ b/cases/tests/test_merges.py
@@ -1,0 +1,126 @@
+import pytest
+from pytest_django.asserts import assertContains, assertNotContains
+from django.contrib.gis.geos import Point
+from accounts.models import User
+from ..models import Case, ActionType, Action
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def case(db):
+    return Case.objects.create(
+        kind="diy",
+        point=Point(470267, 122766),
+        uprn="123456",
+        location_cache="Flat 4, 2 Example Road, E8 2DP",
+    )
+
+
+@pytest.fixture
+def same_case(db):
+    return Case.objects.create(kind="diy", location_cache="Identical case")
+
+
+@pytest.fixture
+def already_merged_case(db):
+    c1 = Case.objects.create(
+        kind="diy",
+        ward="E05009373",
+        location_cache="Combined case",
+        point=Point(470267, 122766),
+    )
+    c2 = Case.objects.create(
+        kind="diy",
+        ward="E05009373",
+        location_cache="Merged case",
+        point=Point(470267, 122766),
+    )
+    Action.objects.create(case=c1, case_old=c2)
+    return c2
+
+
+@pytest.fixture
+def cases(db):
+    return [
+        Case.objects.create(
+            kind="diy",
+            point=Point(470267, 122766),
+            uprn="123456",
+            location_cache="Same UPRN",
+        ),
+        Case.objects.create(
+            kind="diy",
+            point=Point(470267, 122767),
+            location_cache="Within 500m",
+        ),
+        Case.objects.create(
+            kind="diy",
+            point=Point(470267, 123267),
+            location_cache="Too far away",
+        ),
+    ]
+
+
+@pytest.fixture
+def action_types(db):
+    return [
+        ActionType.objects.create(name="Letter sent", common=True),
+        ActionType.objects.create(name="Noise witnessed"),
+        ActionType.objects.create(name="Abatement Notice “Section 80” served"),
+    ]
+
+
+def test_merge_no_location(admin_client, same_case):
+    admin_client.get(f"/cases/{same_case.id}/merge")
+
+
+def test_merge_stop_not_started(admin_client, case):
+    response = admin_client.post(f"/cases/{case.id}/merge", {"stop": 1}, follow=True)
+    assertNotContains(response, "We have forgotten your current merging.")
+
+
+def test_merging_cases_list(admin_client, case, cases, already_merged_case):
+    response = admin_client.post(f"/cases/{case.id}/merge")
+    assertContains(response, "Select a case to merge into")
+    assertContains(response, "Same UPRN")
+    assertContains(response, "Within 500m")
+    assertContains(response, "Combined case")
+    assertNotContains(response, "Too far away")
+    assertNotContains(response, "Merged case")
+    response = admin_client.get(f"/cases/{already_merged_case.id}")
+    assertNotContains(
+        response,
+        f"Merge #{case.id} (DIY at Flat 4, 2 Example Road, E8 2DP) into this case",
+    )
+
+
+def test_merging_case_stopping(admin_client, case, same_case):
+    response = admin_client.post(f"/cases/{case.id}/merge")
+    response = admin_client.get(f"/cases/{same_case.id}")
+    assertContains(
+        response,
+        f"Merge #{case.id} (DIY at Flat 4, 2 Example Road, E8 2DP) into this case",
+    )
+    response = admin_client.post(f"/cases/{case.id}/merge", {"stop": 1}, follow=True)
+    assertContains(response, "We have forgotten your current merging.")
+    assertNotContains(
+        response,
+        f"Merge #{case.id} (DIY at Flat 4, 2 Example Road, E8 2DP) into this case",
+    )
+
+
+def test_merging_cases(admin_client, case, same_case, action_types):
+    response = admin_client.post(f"/cases/{case.id}/merge")
+    response = admin_client.post(
+        f"/cases/{same_case.id}/merge", {"dupe": 1}, follow=True
+    )
+    assertContains(response, "has been merged into")
+
+    a = Action.objects.create(
+        case=same_case, notes="Internal note", type=action_types[1]
+    )
+
+    response = admin_client.get(f"/cases/{case.id}")
+    assertContains(response, "This case has been merged into")
+    assertContains(response, "Noise witnessed")

--- a/cases/tests/tests.py
+++ b/cases/tests/tests.py
@@ -139,31 +139,6 @@ def test_action_output(
     assert str(a) == f"None, case {case_1.id}, unknown action"
 
 
-def test_merging_cases(admin_client, case_1, case_other_uprn, action_types):
-    response = admin_client.post(
-        f"/cases/{case_other_uprn.id}/merge", {"stop": 1}, follow=True
-    )
-    assertNotContains(response, "We have forgotten your current merging.")
-    response = admin_client.post(f"/cases/{case_other_uprn.id}/merge")
-    assertContains(response, "Select a case to merge into")
-    response = admin_client.get(f"/cases/{case_1.id}")
-    assertContains(response, f"Merge #{case_other_uprn.id} (Wombat at Flat 4, 2 Example Road, E8 2DP) into this case")
-    response = admin_client.post(
-        f"/cases/{case_other_uprn.id}/merge", {"stop": 1}, follow=True
-    )
-    assertContains(response, "We have forgotten your current merging.")
-    assertNotContains(response, f"Merge #{case_other_uprn.id} (Wombat at Flat 4, 2 Example Road, E8 2DP) into this case")
-    response = admin_client.post(f"/cases/{case_other_uprn.id}/merge")
-    response = admin_client.post(f"/cases/{case_1.id}/merge", {"dupe": 1}, follow=True)
-    assertContains(response, "has been merged into")
-
-    a = Action.objects.create(case=case_1, notes="Internal note", type=action_types[1])
-
-    response = admin_client.get(f"/cases/{case_other_uprn.id}")
-    assertContains(response, "This case has been merged into")
-    assertContains(response, "Noise witnessed")
-
-
 def test_case_had_abatement(admin_client, case_1, action_types):
     assert not case_1.had_abatement_notice
     response = admin_client.post(

--- a/cases/views.py
+++ b/cases/views.py
@@ -317,10 +317,15 @@ def merge_start(request, case):
         "name": f"{case.kind_display} at {case.location_display}",
     }
 
-    cases_same_uprn = Case.objects.filter(uprn=case.uprn).exclude(id=case.id)
-    cases_nearby = Case.objects.filter(point__dwithin=(case.point, D(m=500))).exclude(
-        id=case.id
-    )
+    qs = Case.objects.unmerged()
+    cases_same_uprn = []
+    cases_nearby = []
+    if case.uprn:
+        cases_same_uprn = qs.filter(uprn=case.uprn).exclude(id=case.id)
+    if case.point:
+        cases_nearby = qs.filter(point__dwithin=(case.point, D(m=500))).exclude(
+            id=case.id
+        )
 
     return render(
         request,


### PR DESCRIPTION
This will not show cases already merged into other cases on the "nearby" lists when you start a merge, nor show the merge button on those cases' pages. This should prevent circular merges and fix #105 