### PR TITLE
Fix invalid escape sequence DeprecationWarning

### DIFF
--- a/cases/views.py
+++ b/cases/views.py
@@ -577,7 +577,7 @@ class ReportingWizard(CaseWizard):
         point = self.request.POST.get("where-map-point")
         radius = self.request.POST.get("where-map-radius")
         for key in self.request.POST:
-            m = re.match("tile_(\d+)\.(\d+)\.([xy])", key)
+            m = re.match(r"tile_(\d+)\.(\d+)\.([xy])", key)
             if m:
                 x, y, d = m.groups()
                 coords[d] = int(self.request.POST[key])


### PR DESCRIPTION
Uses a raw string for a regex, as running the tests locally on Python 3.9.9 resulted in `DeprecationWarning: invalid escape sequence \d` from the `accounts/tests.py::test_bad_token` test.