### PR TITLE
Show better error on OAuth state mismatch.

### DIFF
--- a/oauth/templates/oauth/error.html
+++ b/oauth/templates/oauth/error.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h1>Error</h1>
+
+<p>There was an error logging you in – for security reasons, please make sure
+you are using the same browser where you clicked the staff sign-in link.</p>
+
+<aside class="nw-staff-signin">
+    <a href="{% url "oauth:authenticate" %}">Hackney Staff Sign-in</a>
+</aside>
+
+{% endblock %}


### PR DESCRIPTION
This has happened a small number of times since launch - as best I can tell:
1. Someone starts using the site in IE11.
2. They click the staff sign in link and it redirects to Google OAuth.
3. A/the Google domain is in the Microsoft "Edge only" list - https://docs.microsoft.com/en-us/microsoft-edge/web-platform/ie-to-microsoft-edge-redirection#request-an-update-to-the-ie-compatibility-list - so the OAuth flow redirects to opening in Edge.
4. On redirect back to us, the login fails because the state doesn't match between start (IE11) and end (Edge) of the flow.

I guess we could try and get in the list, or ask for a Group Policy or something but meh