### PR TITLE
Merge/modified updates

### DIFF
--- a/cases/apps.py
+++ b/cases/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class CasesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "cases"
+
+    def ready(self):
+        from . import signals

--- a/cases/models.py
+++ b/cases/models.py
@@ -436,10 +436,9 @@ class Case(AbstractModel):
         return list(complaints)
 
     @property
-    def last_action(self):
+    def last_update(self):
         for event in self.timeline_staff:
-            if "complaint" not in event:
-                return event["action"]
+            return event
         return None
 
     @property

--- a/cases/models.py
+++ b/cases/models.py
@@ -154,7 +154,7 @@ class Case(AbstractModel):
     objects = CaseManager()
 
     class Meta:
-        ordering = ("-id",)
+        ordering = ("-modified", "-id")
 
     @property
     def _history_user(self):

--- a/cases/signals.py
+++ b/cases/signals.py
@@ -1,0 +1,10 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Action, Complaint
+
+
+@receiver(post_save, sender=Complaint)
+@receiver(post_save, sender=Action)
+def update_case(sender, instance, **kwargs):
+    # Update the case last modified
+    instance.case.save()

--- a/cases/templates/cases/_case_last_update.html
+++ b/cases/templates/cases/_case_last_update.html
@@ -1,0 +1,13 @@
+{% if case.last_update %}
+  {% if case.last_update.complaint %}
+    {{ case.last_update.complaint.created }} –
+    <span class="citizen">{{ case.last_update.complaint.complainant }}</span>
+    <span class="case-info">submitted a
+    <a href="{% url "complaint" case.id case.last_update.complaint.id %}">complaint</a></span>
+  {% else %}
+    {{ case.last_update.action.created }} –
+    {% include "cases/_case_action_summary.html" with action=case.last_update.action %}
+  {% endif %}
+{% else %}
+    {{ case.created }} &ndash; initial case submitted
+{% endif %}

--- a/cases/templates/cases/_case_list_item.html
+++ b/cases/templates/cases/_case_list_item.html
@@ -4,6 +4,7 @@
     <a href="{% url 'case-view' case.id %}" class="case-list__title nw-link--no-visited-state">
         {{ case.kind_display }} at {{ case.location_display }}
     </a>
+  {% if not case.merged_into %}
     <dl class="nw-summary-list govuk-summary-list--no-border">
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Complaints</dt>
@@ -29,4 +30,5 @@
             <dd class="govuk-summary-list__value">{{ case.assigned|default:"No-one" }}</dd>
         </div>
     </dl>
+  {% endif %}
 </li>

--- a/cases/templates/cases/_case_list_item.html
+++ b/cases/templates/cases/_case_list_item.html
@@ -17,13 +17,8 @@
             </dd>
         </div>
         <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Last action</dt>
-            <dd class="govuk-summary-list__value">{% if case.last_action %}
-                {{ case.last_action.created }} –
-                {% include "cases/_case_action_summary.html" with action=case.last_action %}
-            {% else %}
-                {{ case.created }} &ndash; initial case submitted
-            {% endif %}</dd>
+            <dt class="govuk-summary-list__key">Last update</dt>
+            <dd class="govuk-summary-list__value">{% include "cases/_case_last_update.html" %}</dd>
         </div>
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Assigned</dt>

--- a/cases/templates/cases/_case_tags.html
+++ b/cases/templates/cases/_case_tags.html
@@ -1,5 +1,8 @@
 <div class="nw-tags">
     <span class="nw-tag nw-tag--id">{{ case.id }}</span>
+  {% if case.merged_into %}
+    <a href="{% url 'case-view' case.merged_into %}"><span class="nw-tag nw-tag--merged">Merged into {{ case.merged_into }}</span></a>
+  {% endif %}
   {% if case.had_abatement_notice %}
     <span class="nw-tag nw-tag--warning">Abatement notice served</span>
   {% endif %}

--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -58,13 +58,8 @@
   </div>
   {% if not case.merged_into %}
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Last action</dt>
-    <dd class="govuk-summary-list__value">{% if case.last_action %}
-        {{ case.last_action.created }} –
-        {% include "cases/_case_action_summary.html" with action=case.last_action %}
-    {% else %}
-        {{ case.created }} &ndash; initial case submitted
-    {% endif %}</dd>
+    <dt class="govuk-summary-list__key">Last update</dt>
+    <dd class="govuk-summary-list__value">{% include "cases/_case_last_update.html" %}</dd>
     <dd class="govuk-summary-list__actions"></dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/cases/views.py
+++ b/cases/views.py
@@ -62,12 +62,7 @@ def case_list_user(request):
 
 @staff_member_required
 def case_list_staff(request):
-    if request.GET.get("search"):
-        # If there is a search, include merged cases so that it can find
-        # the complainant on those cases, those IDs and anything else
-        qs = Case.objects.all()
-    else:
-        qs = Case.objects.unmerged()
+    qs = Case.objects.all()
     f = CaseFilter(request.GET, queryset=qs, request=request)
 
     paginator = Paginator(f.qs, 20)


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/154364/151798575-8b696af0-53f0-4a2d-bfba-94f90eaf8c63.png" width="25%" alt="" align="right">

This does the following:
* Set default case ordering to modified descending, so list pages will show most recent updated first;
* Update case modified when action/complaint saved, so a new complaint or an action a case marks that case as updated too;
* Include merged cases in case listings, marked with a tag (that links).

As new complaints go on merged cases, I think we do need to keep showing them, but with the added last-modified changes so that they hopefully work more appropriately.