### PR TITLE
Fix history display and add new-user option

### DIFF
--- a/cases/tests/test_reporting.py
+++ b/cases/tests/test_reporting.py
@@ -319,7 +319,10 @@ def test_user_case_creation(
     if not logged_in and (email_verified or phone_verified):
         assert Case.objects.count() == 1
         case = Case.objects.all()[0]
-        assert case.created_by_id == normal_user.id
+        if email_verified:
+            assert case.created_by_id == normal_user.id
+        else:
+            assert case.created_by_id != normal_user.id
 
     assert len(mail.outbox) == 2
     assert len(mail.outbox[0].to) == 1

--- a/cases/views.py
+++ b/cases/views.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 import random
 import re
 from django.conf import settings
@@ -767,7 +768,11 @@ class ReportingWizard(CaseWizard):
             user = picker.save()
             user = User.objects.get(id=user)
         else:
-            if self.request.user.is_authenticated:
+            # Make sure these emails always create new unverified users.
+            staff_only = settings.COBRAND_SETTINGS["staff_only_domains_re"]
+            if staff_only and re.search(staff_only, data["email"]):
+                user = User.objects.create_user()
+            elif self.request.user.is_authenticated:
                 user = self.request.user
             else:
                 user = User.objects.check_existing(data["email"])

--- a/cases/views.py
+++ b/cases/views.py
@@ -770,11 +770,10 @@ class ReportingWizard(CaseWizard):
             if self.request.user.is_authenticated:
                 user = self.request.user
             else:
-                user = User.objects.check_existing(data["email"], data["phone"])
+                user = User.objects.check_existing(data["email"])
                 if not user:
                     user = User.objects.create_user(
                         email=data["email"],
-                        phone=data["phone"],
                     )
 
             user.first_name = data["first_name"]

--- a/noiseworks/settings.py
+++ b/noiseworks/settings.py
@@ -249,6 +249,7 @@ COBRAND_SETTINGS = {
         "BUCKET_NAME": env.str("EXPORT_BUCKET_NAME", None),
     },
     "staff_destination": env.json("STAFF_DESTINATION", {}),
+    "staff_only_domains_re": env.str("STAFF_ONLY_DOMAINS", ""),
 }
 
 # Sending messages


### PR DESCRIPTION
Two separate things:
* Fix a bug whereby the 'last update' on a list page could be comparing a HistoricalCase of two different cases (where one had been merged into the other) and thus saying lots of things had changed when they had not;
* Add a config option so that if a new report is created by an email address matching that config option it always creates a new unverified user with the details, rather than using the logged in user or any existing (verified) user.