### PR TITLE
Add controls for specifying time on action form.

### DIFF
--- a/cases/forms/recurrence.py
+++ b/cases/forms/recurrence.py
@@ -4,11 +4,10 @@ import datetime
 from crispy_forms_gds.fields import DateInputField
 from django import forms
 
+from noiseworks.forms import GDSForm
 from noiseworks.forms import StepForm
 
-
-class TimeWidget(forms.TextInput):
-    pass
+from .widgets import TimeWidget
 
 
 def coerce_to_date(d):

--- a/cases/forms/widgets.py
+++ b/cases/forms/widgets.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class TimeWidget(forms.TextInput):
+    pass

--- a/cases/signals.py
+++ b/cases/signals.py
@@ -5,7 +5,17 @@ from .models import Action, Complaint
 
 
 @receiver(post_save, sender=Complaint)
+def update_case_for_complaint(sender, instance, **kwargs):
+    # Update the case last modified
+    instance.case.save()
+
+
 @receiver(post_save, sender=Action)
-def update_case(sender, instance, **kwargs):
+def update_case_for_action(sender, instance, **kwargs):
+    # Action took place before the case was last
+    # modified so don't update it
+    if instance.time < instance.case.modified:
+        return
+
     # Update the case last modified
     instance.case.save()

--- a/cobrand_hackney/static/js.js
+++ b/cobrand_hackney/static/js.js
@@ -65,12 +65,26 @@ function show_hide(input, value, ids) {
     }
 }
 
+function show_hide_checkbox(input, show_when_checked, ids) {
+    var input = document.querySelector(`input[type='checkbox'][name='${input}']`);
+    if (!input) {
+        return;
+    }
+    let f = function() {
+        let show = (input.checked && show_when_checked) || (!input.checked && !show_when_checked);
+        show_hide_toggle(show, ids)
+    };
+    input.addEventListener('change', f);
+    f();
+}
+
 show_hide("kind", "other", ["div_id_kind_other"]);
 show_hide("kind-kind", "other", ["div_id_kind-kind_other"]);
 show_hide("user_pick-user", "0", ['div_id_user_pick-first_name', 'div_id_user_pick-last_name', 'div_id_user_pick-email', 'div_id_user_pick-phone', 'div_id_user_pick-postcode']);
 show_hide("user", "0", ['div_id_first_name', 'div_id_last_name', 'div_id_email', 'div_id_phone', 'div_id_address']);
 show_hide("address-address_uprn", "missing", ["div_id_address-address_manual"]);
 show_hide("user_address-address_uprn", "missing", ["div_id_user_address-address_manual"]);
+show_hide_checkbox("in_the_past", true, ["div_id_date", "div_id_action_time"]);
 
 construct_case_locations_dropdown();
 update_case_listing_on_change();


### PR DESCRIPTION
Added to the bottom of the action form. Note the fields are populated with the current date time by default.

<img width="404" alt="Screenshot 2022-09-08 at 12 40 27" src="https://user-images.githubusercontent.com/9289297/189113338-6c729ce6-0713-4194-9897-057167a6e40e.png">
