### PR TITLE
Use local timezone when compiling dates.

### DIFF
--- a/cases/views.py
+++ b/cases/views.py
@@ -412,14 +412,15 @@ def show_confirmation_step(wizard):
 
 
 def compile_dates(data):
+    local_timezone = timezone.localtime(timezone.now()).tzinfo
     start = datetime.datetime.combine(
-        data["start_date"], data["start_time"], tzinfo=timezone.get_current_timezone()
+        data["start_date"], data["start_time"], tzinfo=local_timezone
     )
     if data["happening_now"]:
         end = timezone.now()
     else:
         end = datetime.datetime.combine(
-            data["start_date"], data["end_time"], tzinfo=timezone.get_current_timezone()
+            data["start_date"], data["end_time"], tzinfo=local_timezone
         )
         if end < start:
             end += datetime.timedelta(days=1)


### PR DESCRIPTION
Running locally, times in my noise complaint got bumped up an hour when saved.
Complaint:
<img width="1064" alt="Screenshot 2022-09-08 at 17 12 57" src="https://user-images.githubusercontent.com/9289297/189175174-902cea3c-52b3-41c6-a128-92ca9336f8f1.png">
Case summary:
<img width="659" alt="Screenshot 2022-09-08 at 17 13 56" src="https://user-images.githubusercontent.com/9289297/189175199-aacf9dce-705a-483b-87ed-60e1169c2430.png">

Ran into something similar with time checking in #135 and fixed the same way by using the local timezone when compiling a date and time rather than `timezone.get_current_timezone()`. Still digging to make sure I fully understand this, I doubt this should be the fix.