### PR TITLE
Fix timezone localisation when compiling dates and times into datetimes.

### DIFF
--- a/cases/views.py
+++ b/cases/views.py
@@ -412,15 +412,14 @@ def show_confirmation_step(wizard):
 
 
 def compile_dates(data):
-    start = datetime.datetime.combine(
-        data["start_date"], data["start_time"], tzinfo=timezone.get_current_timezone()
-    )
+    start = datetime.datetime.combine(data["start_date"], data["start_time"])
+    start = timezone.make_aware(start)
+
     if data["happening_now"]:
         end = timezone.now()
     else:
-        end = datetime.datetime.combine(
-            data["start_date"], data["end_time"], tzinfo=timezone.get_current_timezone()
-        )
+        end = datetime.datetime.combine(data["start_date"], data["end_time"])
+        end = timezone.make_aware(end)
         if end < start:
             end += datetime.timedelta(days=1)
     return start, end


### PR DESCRIPTION
Passing a pytz to a naive datetime constructor as `tzinfo` will literally just attach the exact timezone offset to the datetime. We should use `timezone.aware(naive_datetime)` instead.

This was resulting in times being 1 minute in the future when were in GMT and 1 hour and 1 minute in the future when we were in BST.