### PR TITLE
Fix complaints row in staff case detail summary.

### DIFF
--- a/cases/templates/cases/case_detail_staff.html
+++ b/cases/templates/cases/case_detail_staff.html
@@ -55,6 +55,7 @@
     {% blocktranslate count counter=case.number_all_complainants trimmed %}
     from {{ counter }} complainant{% plural %}from {{ counter }} complainants
     {% endblocktranslate %}</dd>
+    <dd class="govuk-summary-list__actions"></dd>
   </div>
   {% if not case.merged_into %}
   <div class="govuk-summary-list__row">


### PR DESCRIPTION
Tiny thing I noticed.

Before:
<img width="1016" alt="Screenshot 2022-09-13 at 17 46 18" src="https://user-images.githubusercontent.com/9289297/189959734-4b604c3b-e650-4a62-9e5b-c3c3fd81a33f.png">

After:

<img width="1007" alt="Screenshot 2022-09-13 at 17 43 50" src="https://user-images.githubusercontent.com/9289297/189959492-7a4e6774-9855-47ce-a7e5-be7f2539fd6c.png">
