### PR TITLE
Configure a custom user agent for API requests.

### DIFF
--- a/cobrand_hackney/api.py
+++ b/cobrand_hackney/api.py
@@ -16,7 +16,7 @@ if "pytest" in sys.modules:
     session = requests.Session()
 else:  # pragma: no cover
     session = CachedSession(expire_after=86400)
-session.headers.update({"Authorization": api["key"]})
+session.headers.update({"Authorization": api["key"], "User-Agent": api["user_agent"]})
 
 
 def construct_address(address, include_postcode=False):

--- a/noiseworks/settings.py
+++ b/noiseworks/settings.py
@@ -244,6 +244,7 @@ COBRAND_SETTINGS = {
         "url": env.str("ADDRESS_API_URL", "https://example.com/"),
         "pageAttr": env.str("ADDRESS_API_PAGEATTR", "page_count"),
         "key": env.str("ADDRESS_API_KEY", "key"),
+        "user_agent": env.str("USER_AGENT", "noiseworks"),
     },
     "data_export": {
         "ACCESS_KEY_ID": env.str("EXPORT_KEY", None),


### PR DESCRIPTION
This is to hopefully stop nominatim.openstreetmap.org refusing our requests, even though it appears we're sending at a low volume.

See also `noiseworks-configure-ua-and-email` in servers which also sets a `CONTACT_EMAIL` which is included in the search call (see https://nominatim.org/release-docs/latest/api/Search/).

The response we're getting:
[response.html.txt](https://github.com/user-attachments/files/16694631/response.html.txt)
