### PR TITLE
Fix Hackney nearest roads lookup.

### DIFF
--- a/cobrand_hackney/api.py
+++ b/cobrand_hackney/api.py
@@ -158,7 +158,7 @@ def wards():
     )
 
 
-def _wfs_lookup(url, typename, bbox):
+def _wfs_lookup(url, typename, cql_filter):
     r = requests.get(
         f"https://map2.hackney.gov.uk/geoserver/{url}/ows",
         params={
@@ -168,7 +168,7 @@ def _wfs_lookup(url, typename, bbox):
             "typename": typename,
             "outputformat": "json",
             "srsname": "urn:ogc:def:crs:EPSG::27700",
-            "BBOX": bbox,
+            "CQL_FILTER": cql_filter,
         },
     )
     try:
@@ -196,10 +196,8 @@ def in_an_estate(pt):
 
 
 def nearest_roads(pt):
-    filter = (
-        f"<Filter xmlns:gml=\"http://www.opengis.net/gml\"><DWithin><PropertyName>geom</PropertyName><gml:Point><gml:coordinates>{pt.x},{pt.y}</gml:coordinates></gml:Point><Distance units='m'>50</Distance></DWithin></Filter>",
-    )
-    data = _wfs_lookup("transport", "os_highways_street", filter)
+    cql_filter = f"DWITHIN(geom, POINT({pt.x} {pt.y}), 50, meters)"
+    data = _wfs_lookup("transport", "os_highways_street", cql_filter)
     data = _sorted_by_distance(pt, data.get("features", []))
     data = data[:2]
     data = map(lambda x: x["properties"]["name"].title() or "Unknown road", data)

--- a/cobrand_hackney/api.py
+++ b/cobrand_hackney/api.py
@@ -159,17 +159,20 @@ def wards():
 
 
 def _wfs_lookup(url, typename, cql_filter):
-    r = requests.get(
-        f"https://map2.hackney.gov.uk/geoserver/{url}/ows",
-        params={
-            "SERVICE": "WFS",
-            "VERSION": "1.1.0",
-            "REQUEST": "GetFeature",
-            "typename": typename,
-            "outputformat": "json",
-            "srsname": "urn:ogc:def:crs:EPSG::27700",
-            "CQL_FILTER": cql_filter,
-        },
+    params = {
+        "SERVICE": "WFS",
+        "VERSION": "1.1.0",
+        "REQUEST": "GetFeature",
+        "typename": typename,
+        "outputformat": "json",
+        "srsname": "urn:ogc:def:crs:EPSG::27700",
+        "CQL_FILTER": cql_filter,
+    }
+    url = f"https://map2.hackney.gov.uk/geoserver/{url}/ows"
+
+    r = requests.get(url, params)
+    logger.debug(
+        f"Attempted WFS lookup at {url} with query parameters {params}\n Got: {r.text}\nStatus code: {r.status_code}."
     )
     try:
         return r.json()


### PR DESCRIPTION
We set a text description (called the `location_cache`) for the location of a case. For cases where the location was specified by a point, we use Hackney's WFS service to check if the point is in a park, or near roads, and set the description accordingly.

[FD-4406](https://mysocietysupport.freshdesk.com/a/tickets/4406) drew attention to the fact that locations are not being assigned a description as expected when near a road. The most recent case with a description based on a nearby road was in June 2022.

Having made requests manually in the same form the code does, I can see we are hitting 403 errors, however when the filter query parameter is removed, and something like a bbox is specified as with our other WFS requests, it succeeds.

I've changed the requests to use `CQL_FILTER` for the radius queries which appears to work as expected and added some debug logs so we can check it over.